### PR TITLE
This semicolon is invalid and generates a warning from the compiler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! derive_error {
     ($string: tt) => {
         Error::new(Span::call_site(), $string)
             .to_compile_error()
-            .into();
+            .into()
     };
 }
 


### PR DESCRIPTION
compiler says:

> trailing semicolon in macro used in expression position this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release! for more information, see issue [#79813](https://github.com/rust-lang/rust/issues/79813)